### PR TITLE
Added NotifyCollectionChangedAction.Remove to RemoveRange, unit tested

### DIFF
--- a/MvvmHelpers.Tests/MvvmHelpers.Tests.csproj
+++ b/MvvmHelpers.Tests/MvvmHelpers.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -45,5 +45,8 @@
       <Project>{41755AC7-8160-4857-8AA7-6EDCD76923EA}</Project>
       <Name>MvvmHelpers</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 </Project>

--- a/MvvmHelpers.Tests/ObservableRangeTests.cs
+++ b/MvvmHelpers.Tests/ObservableRangeTests.cs
@@ -33,9 +33,34 @@ namespace MvvmHelpers.Tests
                                   orderby person.LastName
                                   group person by person.SortName into personGroup
                                   select new Grouping<string, Person>(personGroup.Key, personGroup);
-
+       
             grouped.AddRange(sorted);
            
+        }
+
+        [Test()]
+        public void RemoveRange_RemoveTest()
+        {
+            ObservableRangeCollection<int> collection = new ObservableRangeCollection<int>();
+            int[] toAdd = new[] { 3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3 };
+            int[] toRemove = new[] { 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 0, 0 };
+            collection.AddRange(toAdd);
+            collection.CollectionChanged += (s, e) =>
+            {
+                if (e.Action != System.Collections.Specialized.NotifyCollectionChangedAction.Remove)
+                    Assert.Fail("RemoveRange didn't use Remove like requested.");
+                if (e.OldItems == null)
+                    Assert.Fail("OldItems should not be null.");
+                int[] expected = new int[] { 1, 1, 2, 2, 3, 3, 4, 5, 5, 6, 7, 8, 9, 9 };
+                if (expected.Length != e.OldItems.Count)
+                    Assert.Fail("Expected and actual OldItems don't match.");
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    if (expected[i] != (int)e.OldItems[i])
+                        Assert.Fail("Expected and actual OldItems don't match.");
+                }
+            };
+            collection.RemoveRange(toRemove, System.Collections.Specialized.NotifyCollectionChangedAction.Remove);
         }
     }
 }

--- a/MvvmHelpers/ObservableRangeCollection.cs
+++ b/MvvmHelpers/ObservableRangeCollection.cs
@@ -37,6 +37,8 @@ namespace MvvmHelpers
         /// </summary> 
         public void AddRange(IEnumerable<T> collection, NotifyCollectionChangedAction notificationMode = NotifyCollectionChangedAction.Add)
         {
+            if (notificationMode != NotifyCollectionChangedAction.Add && notificationMode != NotifyCollectionChangedAction.Reset)
+                throw new ArgumentException("Mode must be either Add or Reset for AddRange.", "notificationMode");
             if (collection == null)
                 throw new ArgumentNullException("collection");
 
@@ -69,16 +71,40 @@ namespace MvvmHelpers
         }
 
         /// <summary> 
-        /// Removes the first occurence of each item in the specified collection from ObservableCollection(Of T). 
+        /// Removes the first occurence of each item in the specified collection from ObservableCollection(Of T). NOTE: with notificationMode = Remove, removed items starting index is not set because items are not guaranteed to be consecutive.
         /// </summary> 
-        public void RemoveRange(IEnumerable<T> collection)
+        public void RemoveRange(IEnumerable<T> collection, NotifyCollectionChangedAction notificationMode = NotifyCollectionChangedAction.Reset)
         {
+            if (notificationMode != NotifyCollectionChangedAction.Remove && notificationMode != NotifyCollectionChangedAction.Reset)
+                throw new ArgumentException("Mode must be either Remove or Reset for RemoveRange.", "notificationMode");
             if (collection == null)
                 throw new ArgumentNullException("collection");
 
-            foreach (var i in collection)
-                Items.Remove(i);
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            CheckReentrancy();
+
+            if (notificationMode == NotifyCollectionChangedAction.Reset)
+            {
+
+                foreach (var i in collection)
+                    Items.Remove(i);
+                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+
+                return;
+            }
+            
+            var changedItems = collection is List<T> ? (List<T>)collection : new List<T>(collection);
+            for (int i = 0; i < changedItems.Count; i++)
+            {
+                if (!Items.Remove(changedItems[i]))
+                {
+                    changedItems.RemoveAt(i); //Can't use a foreach because changedItems is intended to be (carefully) modified
+                    i--;
+                }
+            }
+
+            OnPropertyChanged(new PropertyChangedEventArgs("Count"));
+            OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, changedItems, -1));
         }
 
         /// <summary> 


### PR DESCRIPTION
Changed RemoveRange to (optionally) use remove mode instead of reset, with the caveat documented that the starting index will not be specified because the removed items are not guaranteed to be adjacent. RemoveRange still defaults to reset, so this doesn't break existing code.