### PR TITLE
Support .NET Standard 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ build/
 [Cc]omponents/
 [Pp]ackages/
 
+# Dotnet core
+*.lock.json
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/MvvmHelpers.nuspec
+++ b/MvvmHelpers.nuspec
@@ -23,8 +23,8 @@
    </metadata>
    <files>
   <!--Core-->
-     <file src="MvvmHelpers/bin/Release/MvvmHelpers.dll" target="lib\portable-net45+wp80+win8+wpa81\MvvmHelpers.dll" />
-     <file src="MvvmHelpers/bin/Release/MvvmHelpers.xml" target="lib\portable-net45+wp80+win8+wpa81\MvvmHelpers.xml" />
-     <file src="MvvmHelpers/bin/Release/MvvmHelpers.pdb" target="lib\portable-net45+wp80+win8+wpa81\MvvmHelpers.pdb" />
+     <file src="MvvmHelpers/bin/Release/MvvmHelpers.dll" target="lib\netstandard1.0\MvvmHelpers.dll" />
+     <file src="MvvmHelpers/bin/Release/MvvmHelpers.xml" target="lib\netstandard1.0\MvvmHelpers.xml" />
+     <file src="MvvmHelpers/bin/Release/MvvmHelpers.pdb" target="lib\netstandard1.0\MvvmHelpers.pdb" />
    </files>
 </package>

--- a/MvvmHelpers/MvvmHelpers.csproj
+++ b/MvvmHelpers/MvvmHelpers.csproj
@@ -8,9 +8,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>MvvmHelpers</RootNamespace>
     <AssemblyName>MvvmHelpers</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,6 +41,9 @@
     <Compile Include="Grouping.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="ObservableObject.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/MvvmHelpers/project.json
+++ b/MvvmHelpers/project.json
@@ -1,0 +1,10 @@
+﻿{
+  "supports": {},
+  "dependencies": {
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+    "NETStandard.Library": "1.6.0"
+  },
+  "frameworks": {
+    "netstandard1.0": {}
+  }
+}


### PR DESCRIPTION
.NET Standard 1.0 is the only standard which supports Windows Phone Silverlight 8.0.
The nuspec should proberly be updated because it's proberly using Nuget 2.x and therefore gives the warning "The folder 'netstandard1.0' under 'lib' is not recognized as a valid framework name or a supported culture identifier."