### PR TITLE
Made OnPropertyChanged a virtual method so it could be overridden.

### DIFF
--- a/MvvmHelpers/ObservableObject.cs
+++ b/MvvmHelpers/ObservableObject.cs
@@ -37,11 +37,12 @@ namespace MvvmHelpers
         /// Occurs when property changed.
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
+        
         /// <summary>
         /// Raises the property changed event.
         /// </summary>
         /// <param name="propertyName">Property name.</param>
-        protected void OnPropertyChanged([CallerMemberName]string propertyName = "") =>
+        protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = "") =>
          PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     }


### PR DESCRIPTION
I have often found that I need to trigger something when any property changes in my view model and overriding the OnPropertyChanged method is a good way to do it.