### PR TITLE
Optimized to increase UI performance

### DIFF
--- a/MvvmHelpers.Tests/MvvmHelpers.Tests.csproj
+++ b/MvvmHelpers.Tests/MvvmHelpers.Tests.csproj
@@ -48,6 +48,7 @@
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System.ObjectModel" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GroupingTests.cs" />


### PR DESCRIPTION
Hi @jamesmontemagno, I'd like to thank you for sharing the ORC here.
In my use case I have a large collection that changes upon user key strokes (meaning: it 5-10 times a second), and the ORC you shared was still a bit laggy, so I decided to optimize it and added some of the following features.
I'd really hope if you can accept my PR so other people can benefit.

1. Add safe filters to skip unnecessary actions
2. The `RemoveRange` action was throwing exceptions and caused UI issues when calling with `NotifyCollectionChangedAction.Remove`. I hence updated the `RemoveRange` to raise a separate remove event for each consecutive item cluster in the ORC, which dramatically improved the performance 
3. After a lot of experiments, my conclusion is clear, the key impact on UI performance of the ORC is resetting elements when not necessary. Reusing them however significantly boosts performance. Therefore, I updated the `ReplaceRange` to allow for reusing existing elements or at least retain their index and just updating the element, and only raise events (batched when possible - unfortunately, `Raplace` is not allowed for multiple items). More events costs way less performance than resetting items or not reusing them.