### PR TITLE
ReplaceRange on non empty ObservableRangeCollection with empty collection does not raise event

### DIFF
--- a/MvvmHelpers.UnitTests/ObservableRangeTests.cs
+++ b/MvvmHelpers.UnitTests/ObservableRangeTests.cs
@@ -5,7 +5,7 @@ namespace MvvmHelpers.UnitTests
 {
 	[TestClass]
 	public class ObservableRangeTests
-	{
+	{		
 		[TestMethod]
 		public void AddRange()
 		{
@@ -70,6 +70,36 @@ namespace MvvmHelpers.UnitTests
 						Assert.Fail("Expected and actual items don't match.");
 				}
 			};
+			collection.ReplaceRange(toAdd);
+		}
+		
+		[TestMethod]
+		public void ReplaceRange_on_non_empty_collection_should_always_raise_collection_changes()
+		{
+			var collection = new ObservableRangeCollection<int>(new [] { 1 });
+			var toAdd = new int[0];
+			var eventRaised = false;
+						
+			collection.CollectionChanged += (s, e) =>
+			{
+				eventRaised = true;
+			};
+			
+			collection.ReplaceRange(toAdd);
+			Assert.IsTrue(eventRaised, "Collection Reset should be raised.")
+		}
+		
+		[TestMethod]
+		public void ReplaceRange_on_empty_collection_should_NOT_raise_collection_changes_when_empty()
+		{
+			var collection = new ObservableRangeCollection<int>();
+			var toAdd = new int[0];
+						
+			collection.CollectionChanged += (s, e) =>
+			{
+				Assert.Fail("Collection changes should NOT be raised.");
+			};
+			
 			collection.ReplaceRange(toAdd);
 		}
 

--- a/MvvmHelpers.UnitTests/ObservableRangeTests.cs
+++ b/MvvmHelpers.UnitTests/ObservableRangeTests.cs
@@ -86,7 +86,7 @@ namespace MvvmHelpers.UnitTests
 			};
 			
 			collection.ReplaceRange(toAdd);
-			Assert.IsTrue(eventRaised, "Collection Reset should be raised.")
+			Assert.IsTrue(eventRaised, "Collection Reset should be raised.");
 		}
 		
 		[TestMethod]


### PR DESCRIPTION
Added Failing Testes pointing out issue #50 whereby the following

```csharp
new ObservableRangeCollection<Any>(new [] { any }).ReplaceRange(new Any[0]);
```
would raise collection change events.

The test was faster to write. the fix will come in later