### PR TITLE
ObservableRangeCollection mutates the source when using Remove mode

### DIFF
--- a/MvvmHelpers.UnitTests/ObservableRangeTests.cs
+++ b/MvvmHelpers.UnitTests/ObservableRangeTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 
 namespace MvvmHelpers.UnitTests
@@ -103,6 +104,17 @@ namespace MvvmHelpers.UnitTests
 			collection.ReplaceRange(toAdd);
 		}
 
+		[TestMethod]
+		public void ReplaceRange_should_NOT_mutate_source()
+		{
+			var sourceData = new List<int>(new[] { 1, 2, 3 });
+			var collection = new ObservableRangeCollection<int>(new[] { 4, 5, 6 });
+
+			collection.RemoveRange(sourceData);
+
+			Assert.IsTrue(sourceData.Count == 3, "source data was mutated");
+			Assert.IsTrue(collection.Count == 3, "collection was mutated");
+		}
 
 		[TestMethod]
 		public void RemoveRangeRemoveTestMethod()
@@ -143,6 +155,17 @@ namespace MvvmHelpers.UnitTests
 			};
 			collection.RemoveRange(toRemove, NotifyCollectionChangedAction.Remove);
 		}
+
+		[TestMethod]
+		public void RemoveRange_should_NOT_mutate_source()
+		{
+			var sourceData = new List<int>(new[] { 1, 2, 3 }); 
+			var collection = new ObservableRangeCollection<int>(new[] { 4, 5, 6 });
+
+			collection.RemoveRange(sourceData, NotifyCollectionChangedAction.Remove);
+
+			Assert.IsTrue(sourceData.Count == 3, "source data was mutated");
+			Assert.IsTrue(collection.Count == 3, "collection was mutated");
+		}
 	}
 }
-

--- a/MvvmHelpers/ObservableRangeCollection.cs
+++ b/MvvmHelpers/ObservableRangeCollection.cs
@@ -93,7 +93,7 @@ namespace MvvmHelpers
 				return;
 			}
 
-			var changedItems = collection is List<T> ? (List<T>)collection : new List<T>(collection);
+			var changedItems = new List<T>(collection);
 			for (var i = 0; i < changedItems.Count; i++)
 			{
 				if (!Items.Remove(changedItems[i]))


### PR DESCRIPTION
When the `RemoveRange()` method is called with 'Remove' mode and the list of items to be removed are not in the collection, the list of changed items will point to the original source if the source is itself a List<T>. `RemoveRange()` must use its own copy to avoid mutation.

Tests added (used Red-Green-Refactor) to confirm the issue.