### PR TITLE
Correction to RemoveRange/ReplaceRange unit tests

### DIFF
--- a/MvvmHelpers.UnitTests/ObservableRangeTests.cs
+++ b/MvvmHelpers.UnitTests/ObservableRangeTests.cs
@@ -108,12 +108,11 @@ namespace MvvmHelpers.UnitTests
 		public void ReplaceRange_should_NOT_mutate_source()
 		{
 			var sourceData = new List<int>(new[] { 1, 2, 3 });
-			var collection = new ObservableRangeCollection<int>(new[] { 4, 5, 6 });
+			var collection = new ObservableRangeCollection<int>(new[] { 1, 2, 3, 4, 5, 6 });
 
-			collection.RemoveRange(sourceData);
+			collection.ReplaceRange(sourceData);
 
 			Assert.IsTrue(sourceData.Count == 3, "source data was mutated");
-			Assert.IsTrue(collection.Count == 3, "collection was mutated");
 		}
 
 		[TestMethod]
@@ -157,7 +156,7 @@ namespace MvvmHelpers.UnitTests
 		}
 
 		[TestMethod]
-		public void RemoveRange_should_NOT_mutate_source()
+		public void RemoveRange_should_NOT_mutate_source_when_source_data_is_not_present()
 		{
 			var sourceData = new List<int>(new[] { 1, 2, 3 }); 
 			var collection = new ObservableRangeCollection<int>(new[] { 4, 5, 6 });
@@ -165,7 +164,29 @@ namespace MvvmHelpers.UnitTests
 			collection.RemoveRange(sourceData, NotifyCollectionChangedAction.Remove);
 
 			Assert.IsTrue(sourceData.Count == 3, "source data was mutated");
-			Assert.IsTrue(collection.Count == 3, "collection was mutated");
+		}
+
+		[TestMethod]
+		public void RemoveRange_should_NOT_mutate_source_when_source_data_is_present()
+		{
+			var sourceData = new List<int>(new[] { 1, 2, 3 });
+			var collection = new ObservableRangeCollection<int>(new[] { 1, 2, 3, 4, 5, 6 });
+
+			collection.RemoveRange(sourceData, NotifyCollectionChangedAction.Remove);
+
+			Assert.IsTrue(sourceData.Count == 3, "source data was mutated");
+		}
+
+		[TestMethod]
+		public void RemoveRange_should_NOT_mutate_collection_when_source_data_is_not_present()
+		{
+			var sourceData = new List<int>(new[] { 1, 2, 3 });
+			var collection = new ObservableRangeCollection<int>(new[] { 4, 5, 6, 7, 8, 9 });
+
+			collection.RemoveRange(sourceData, NotifyCollectionChangedAction.Remove);
+
+			// the collection should not be modified if the source items are not found
+			Assert.IsTrue(collection.Count == 6, "collection was mutated");
 		}
 	}
 }

--- a/MvvmHelpers.UnitTests/ObservableRangeTests.cs
+++ b/MvvmHelpers.UnitTests/ObservableRangeTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 
 namespace MvvmHelpers.UnitTests
@@ -103,6 +104,17 @@ namespace MvvmHelpers.UnitTests
 			collection.ReplaceRange(toAdd);
 		}
 
+		[TestMethod]
+		public void ReplaceRange_should_NOT_mutate_source()
+		{
+			var sourceData = new List<int>(new[] { 1, 2, 3 });
+			var collection = new ObservableRangeCollection<int>(new[] { 4, 5, 6 });
+
+			collection.RemoveRange(sourceData);
+
+			Assert.IsTrue(sourceData.Count == 3, "source data was mutated");
+			Assert.IsTrue(collection.Count == 3, "collection was mutated");
+		}
 
 		[TestMethod]
 		public void RemoveRangeRemoveTestMethod()
@@ -143,6 +155,17 @@ namespace MvvmHelpers.UnitTests
 			};
 			collection.RemoveRange(toRemove, NotifyCollectionChangedAction.Remove);
 		}
+
+		[TestMethod]
+		public void RemoveRange_should_NOT_mutate_source()
+		{
+			var sourceData = new List<int>(new[] { 1, 2, 3 }); 
+			var collection = new ObservableRangeCollection<int>(new[] { 4, 5, 6 });
+
+			collection.RemoveRange(sourceData, NotifyCollectionChangedAction.Remove);
+
+			Assert.IsTrue(sourceData.Count == 3, "source data was mutated");
+			Assert.IsTrue(collection.Count == 3, "collection was mutated");
+		}
 	}
 }
-

--- a/MvvmHelpers/ObservableRangeCollection.cs
+++ b/MvvmHelpers/ObservableRangeCollection.cs
@@ -93,7 +93,7 @@ namespace MvvmHelpers
 				return;
 			}
 
-			var changedItems = collection is List<T> ? (List<T>)collection : new List<T>(collection);
+			var changedItems = new List<T>(collection);
 			for (var i = 0; i < changedItems.Count; i++)
 			{
 				if (!Items.Remove(changedItems[i]))


### PR DESCRIPTION
Oops, I really should not have created that recent PR so late at night. Upon reviewing them again today I noticed one test was calling the wrong method (`RemoveRange` instead of `ReplaceRange`) and I wasn't happy that I had two tests combined as one so have made them more explicit.