### PR TITLE
Handled PropertyChanged event with WeakEventManager

### DIFF
--- a/MvvmHelpers.UnitTests/WeakEventManagerTests.cs
+++ b/MvvmHelpers.UnitTests/WeakEventManagerTests.cs
@@ -78,6 +78,30 @@ namespace MvvmHelpers.UnitTests
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(ArgumentNullException))]
+		public void AddPropertyChangedHandlerWithEmptyEventNameThrowsException()
+		{
+			var wem = new WeakEventManager();
+			wem.AddPropertyChangedEventHandler((sender, args) => { }, "");
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentNullException))]
+		public void AddPropertyChangedHandlerWithNullEventHandlerThrowsException()
+		{
+			var wem = new WeakEventManager();
+			wem.AddPropertyChangedEventHandler(null, "test");
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentNullException))]
+		public void AddPropertyChangedHandlerWithNullEventNameThrowsException()
+		{
+			var wem = new WeakEventManager();
+			wem.AddPropertyChangedEventHandler((sender, args) => { }, null);
+		}
+
+		[TestMethod]
 		public void CanRemoveEventHandler()
 		{
 			var source = new TestSource();
@@ -167,6 +191,38 @@ namespace MvvmHelpers.UnitTests
 		{
 			var wem = new WeakEventManager();
 			wem.RemoveEventHandler((sender, args) => { }, "fake");
+			wem.RemoveEventHandler(Handler, "alsofake");
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentNullException))]
+		public void RemovePropertyChangedHandlerWithEmptyEventNameThrowsException()
+		{
+			var wem = new WeakEventManager();
+			wem.RemovePropertyChangedEventHandler((sender, args) => { }, "");
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentNullException))]
+		public void RemovePropertyChangedHandlerWithNullEventHandlerThrowsException()
+		{
+			var wem = new WeakEventManager();
+			wem.RemovePropertyChangedEventHandler(null, "test");
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentNullException))]
+		public void RemovePropertyChangedHandlerWithNullEventNameThrowsException()
+		{
+			var wem = new WeakEventManager();
+			wem.RemovePropertyChangedEventHandler((sender, args) => { }, null);
+		}
+
+		[TestMethod]
+		public void RemovingPropertyChangedNonExistentHandlersShouldNotThrow()
+		{
+			var wem = new WeakEventManager();
+			wem.RemovePropertyChangedEventHandler((sender, args) => { }, "fake");
 			wem.RemoveEventHandler(Handler, "alsofake");
 		}
 

--- a/MvvmHelpers/ObservableObject.cs
+++ b/MvvmHelpers/ObservableObject.cs
@@ -10,6 +10,8 @@ namespace MvvmHelpers
 	/// </summary>
 	public class ObservableObject : INotifyPropertyChanged
 	{
+		readonly WeakEventManager weakEventManager = new WeakEventManager();
+
 		/// <summary>
 		/// Sets the property.
 		/// </summary>
@@ -44,15 +46,17 @@ namespace MvvmHelpers
 		/// <summary>
 		/// Occurs when property changed.
 		/// </summary>
-		public event PropertyChangedEventHandler? PropertyChanged;
+		public event PropertyChangedEventHandler PropertyChanged
+		{
+			add { weakEventManager.AddPropertyChangedEventHandler(value); }
+			remove { weakEventManager.RemovePropertyChangedEventHandler(value); }
+		}
 
 		/// <summary>
 		/// Raises the property changed event.
 		/// </summary>
 		/// <param name="propertyName">Property name.</param>
 		protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = "") =>
-		 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
+			weakEventManager.HandleEvent(this, new PropertyChangedEventArgs(propertyName), nameof(PropertyChanged));
 	}
 }
-

--- a/MvvmHelpers/WeakEventManager.cs
+++ b/MvvmHelpers/WeakEventManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -38,6 +39,22 @@ namespace MvvmHelpers
 		/// <param name="handler">Handler of the event</param>
 		/// <param name="eventName">Name to use in the dictionary. Should be unique.</param>
 		public void AddEventHandler(EventHandler handler, [CallerMemberName]string eventName = "")
+		{
+			if (IsNullOrEmpty(eventName))
+				throw new ArgumentNullException(nameof(eventName));
+
+			if (handler == null)
+				throw new ArgumentNullException(nameof(handler));
+
+			AddEventHandler(eventName, handler.Target, handler.GetMethodInfo());
+		}
+
+		/// <summary>
+		/// Adds an property changed event handler to the manager.
+		/// </summary>
+		/// <param name="handler">Handler of the event</param>
+		/// <param name="eventName">Name to use in the dictionary. Should be unique.</param>
+		public void AddPropertyChangedEventHandler(PropertyChangedEventHandler handler, [CallerMemberName] string eventName = "PropertyChanged")
 		{
 			if (IsNullOrEmpty(eventName))
 				throw new ArgumentNullException(nameof(eventName));
@@ -119,6 +136,22 @@ namespace MvvmHelpers
 		/// <param name="handler">Handler to remove</param>
 		/// <param name="eventName">Event name to remove</param>
 		public void RemoveEventHandler(EventHandler handler, [CallerMemberName]string eventName = "")
+		{
+			if (IsNullOrEmpty(eventName))
+				throw new ArgumentNullException(nameof(eventName));
+
+			if (handler is null)
+				throw new ArgumentNullException(nameof(handler));
+
+			RemoveEventHandler(eventName, handler.Target, handler.GetMethodInfo());
+		}
+
+		/// <summary>
+		/// Remove an event handler.
+		/// </summary>
+		/// <param name="handler">Handler to remove</param>
+		/// <param name="eventName">Event name to remove</param>
+		public void RemovePropertyChangedEventHandler(PropertyChangedEventHandler handler, [CallerMemberName] string eventName = "")
 		{
 			if (IsNullOrEmpty(eventName))
 				throw new ArgumentNullException(nameof(eventName));


### PR DESCRIPTION
Hi James,
as discussed in issue https://github.com/jamesmontemagno/mvvm-helpers/issues/71, I submit this PR to handle PropertyChanged with the WeakEventManager too.
I have extended the WeakEventManager and added also unit tests to check the new methods.
The behavior of the PropertyChanged event was already tested, so I felt I didn't need to add anything more.