### PR TITLE
Replace notification when resulting collection is not empty in ReplaceRange method

### DIFF
--- a/MvvmHelpers/ObservableRangeCollection.cs
+++ b/MvvmHelpers/ObservableRangeCollection.cs
@@ -137,7 +137,7 @@ namespace MvvmHelpers
 			if (previouslyEmpty && currentlyEmpty)
 				return;
 
-			RaiseChangeNotificationEvents(action: NotifyCollectionChangedAction.Reset);
+			RaiseChangeNotificationEvents(action: currentlyEmpty ? NotifyCollectionChangedAction.Reset : NotifyCollectionChangedAction.Replace);
 		}
 
 		private bool AddArrangeCore(IEnumerable<T> collection)


### PR DESCRIPTION
When resulting collection is empty Replace notification should be raised instead of Reset.