### PR TITLE
When doing the AddRange to an ObservableRangeCollection the gui ain't refreshed in certain cases

### DIFF
--- a/MvvmHelpers.UnitTests/ObservableRangeTests.cs
+++ b/MvvmHelpers.UnitTests/ObservableRangeTests.cs
@@ -195,6 +195,7 @@ namespace MvvmHelpers.UnitTests
 		{
 			var collection = new ObservableRangeCollection<int>(new[] { 1, 2, 3 });
 			var addedData = new List<int> { 4, 5 };
+			var mergedData = collection.Concat(addedData).ToList();
 
 			collection.CollectionChanged += (s, e) =>
 			{
@@ -207,7 +208,11 @@ namespace MvvmHelpers.UnitTests
 
 			collection.AddRange(addedData.Where(x => !collection.Contains(x)));
 
-			Assert.IsTrue(collection.Count == 5);
+			Assert.IsTrue(collection.Count == mergedData.Count);
+			for (var i = 0; i < mergedData.Count; i++)
+			{
+				Assert.AreEqual(mergedData[i], collection[i]);
+			}
 		}
 	}
 }

--- a/MvvmHelpers.UnitTests/ObservableRangeTests.cs
+++ b/MvvmHelpers.UnitTests/ObservableRangeTests.cs
@@ -191,16 +191,23 @@ namespace MvvmHelpers.UnitTests
 		}
 
 		[TestMethod]
-		public void AddData()
+		public void AddRangeShouldHaveCorrectDataInCollectionChanged()
 		{
 			var collection = new ObservableRangeCollection<int>(new[] { 1, 2, 3 });
 			var addedData = new List<int> { 4, 5 };
 
+			collection.CollectionChanged += (s, e) =>
+			{
+				Assert.AreEqual(addedData.Count, e.NewItems.Count);
+				for (var i = 0; i < addedData.Count; i++)
+				{
+					Assert.AreEqual(addedData[i], (int)e.NewItems[i]);
+				}
+			};
+
 			collection.AddRange(addedData.Where(x => !collection.Contains(x)));
 
 			Assert.IsTrue(collection.Count == 5);
-			//The argument changedItems in RaiseChangeNotificationEvents should be the addedData list.
-			//No way to verify that here though.
 		}
 	}
 }

--- a/MvvmHelpers.UnitTests/ObservableRangeTests.cs
+++ b/MvvmHelpers.UnitTests/ObservableRangeTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 
 namespace MvvmHelpers.UnitTests
 {
@@ -187,6 +188,19 @@ namespace MvvmHelpers.UnitTests
 
 			// the collection should not be modified if the source items are not found
 			Assert.IsTrue(collection.Count == 6, "collection was mutated");
+		}
+
+		[TestMethod]
+		public void AddData()
+		{
+			var collection = new ObservableRangeCollection<int>(new[] { 1, 2, 3 });
+			var addedData = new List<int> { 4, 5 };
+
+			collection.AddRange(addedData.Where(x => !collection.Contains(x)));
+
+			Assert.IsTrue(collection.Count == 5);
+			//The argument changedItems in RaiseChangeNotificationEvents should be the addedData list.
+			//No way to verify that here though.
 		}
 	}
 }

--- a/MvvmHelpers/ObservableRangeCollection.cs
+++ b/MvvmHelpers/ObservableRangeCollection.cs
@@ -48,7 +48,7 @@ namespace MvvmHelpers
 
 			var changedItems = collection is List<T> ? (List<T>)collection : new List<T>(collection);
 
-			var itemsAdded = AddArrangeCore(changedItems);
+			var itemsAdded = AddArrangeCore(collection);
 
 			if (!itemsAdded)
 				return;
@@ -59,7 +59,6 @@ namespace MvvmHelpers
 
 				return;
 			}
-
 
 			RaiseChangeNotificationEvents(
 				action: NotifyCollectionChangedAction.Add,

--- a/MvvmHelpers/ObservableRangeCollection.cs
+++ b/MvvmHelpers/ObservableRangeCollection.cs
@@ -48,7 +48,7 @@ namespace MvvmHelpers
 
 			var changedItems = collection is List<T> ? (List<T>)collection : new List<T>(collection);
 
-			var itemsAdded = AddArrangeCore(collection);
+			var itemsAdded = AddArrangeCore(changedItems);
 
 			if (!itemsAdded)
 				return;

--- a/MvvmHelpers/ObservableRangeCollection.cs
+++ b/MvvmHelpers/ObservableRangeCollection.cs
@@ -46,7 +46,9 @@ namespace MvvmHelpers
 
 			var startIndex = Count;
 
-			var itemsAdded = AddArrangeCore(collection);
+			var changedItems = collection is List<T> ? (List<T>)collection : new List<T>(collection);
+
+			var itemsAdded = AddArrangeCore(changedItems);
 
 			if (!itemsAdded)
 				return;
@@ -58,7 +60,6 @@ namespace MvvmHelpers
 				return;
 			}
 
-			var changedItems = collection is List<T> ? (List<T>)collection : new List<T>(collection);
 
 			RaiseChangeNotificationEvents(
 				action: NotifyCollectionChangedAction.Add,


### PR DESCRIPTION
When doing the AddRange to an ObservableRangeCollection the gui ain't refreshed in certain cases.
This only happens when you supply an `IEnumerable<T>` as parameter to the `AddRange` method and the `IEnumerable<T>` also hold a reference to "itself" (see the `collection.AddRange(addedData.Where(x => !collection.Contains(x)));` in the `AddData` unittest.
This is cause the IEnumerable is enumerated multiple times, which results in:
`var changedItems = collection is List<T> ? (List<T>)collection : new List<T>(collection);`
to be an empty list (after the AddArrangeCore method).
This emty list is passed to the RaiseChangeNotificationEvents which doesn't cause an update of the GUI

Note: as far as I can see, this only occurs for the `AddRange` method and not for the `DeleteRange` method
Note2: this is a fix for #69 